### PR TITLE
Error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ Lightrail is a modern platform for digital account credits, gift cards, promotio
 
 If you are looking for specific use-cases or other languages, check out the *Integrations* section of the [Lightrail API documentation](https://www.lightrail.com/docs/).
 
-## Important
-
-This library is in _beta_ mode and may have breaking changes before v1.0.0.
-
 ## Features
 
 - Simple order checkout supporting split-tender transactions with Lightrail redemption alongside a Stripe payment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightrail-stripe",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Javascript and Typescript library for creating Lightrail-Stripe integrated applications.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,24 @@
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+
+chai.use(chaiAsPromised);
+
+const stripeAPIKey = process.env.STRIPE_SECRET_KEY;
+const lightrailAPIKey = process.env.LIGHTRAIL_API_KEY;
+const lightrailShopperId = process.env.LIGHTRAIL_SHOPPER_ID;
+
+const stripe = require("stripe")(
+    stripeAPIKey
+);
+
+describe("set up test config", () => {
+    it("has a Lightrail API key", () => {
+        chai.assert.isString(lightrailAPIKey, "Lightrail API key must be a string: see readme to configure");
+    });
+    it("has a Stripe API key", () => {
+        chai.assert.isString(stripeAPIKey, "Stripe API key must be a string: see readme to configure");
+    });
+    it("has a Lightrail shopper ID", () => {
+        chai.assert.isString(lightrailShopperId, "Lightrail shopper ID must be a string: see readme to configure");
+    });
+});

--- a/src/stripeLightrailSplitTenderTransactions.test.ts
+++ b/src/stripeLightrailSplitTenderTransactions.test.ts
@@ -110,6 +110,15 @@ describe("stripeLightrailSplitTenderTransactions", () => {
                 const res = await lightrailSplitTender.createSplitTenderCharge(stripeOnlyParams, 0, stripe);
                 chai.assert.equal(res.stripeCharge.amount, stripeOnlyParams.amount);
             });
+
+            describe("error handling", () => {
+                it("re-throws a Stripe error (bad Stripe object)", async () => {
+                    const badStripe = require("stripe")("abc");
+                    splitTenderChargeParams.userSuppliedId = uuid();
+                    chai.assert.isRejected(lightrailSplitTender.createSplitTenderCharge(splitTenderChargeParams, 1, badStripe));
+                });
+            });
+
         });
 
         describe("using Stripe secret key", () => {
@@ -137,6 +146,15 @@ describe("stripeLightrailSplitTenderTransactions", () => {
                 const res = await lightrailSplitTender.createSplitTenderCharge(stripeOnlyParams, 0, stripeAPIKey);
                 chai.assert.equal(res.stripeCharge.amount, stripeOnlyParams.amount);
             });
+
+            describe("error handling", () => {
+                it("re-throws a Stripe error (bad Stripe API key)", async () => {
+                    const badStripeKey = "abc";
+                    splitTenderChargeParams.userSuppliedId = uuid();
+                    chai.assert.isRejected(lightrailSplitTender.createSplitTenderCharge(splitTenderChargeParams, 1, badStripeKey));
+                });
+            });
+
         });
     });
 

--- a/src/stripeLightrailSplitTenderTransactions.test.ts
+++ b/src/stripeLightrailSplitTenderTransactions.test.ts
@@ -175,7 +175,7 @@ describe("stripeLightrailSplitTenderTransactions", () => {
                 chai.assert.exists(res.lightrailTransaction.value);
             });
 
-            it("simulates posting a charge to Lightrail: nsf true", async () => {
+            it("simulates posting a charge to Lightrail: nsf true (promise rejects if card can't cover charge)", async () => {
                 simulateSplitTenderChargeParams.userSuppliedId = uuid();
                 simulateSplitTenderChargeParams.nsf = true;
                 simulateSplitTenderChargeParams.amount = lightrailShareForNSF;

--- a/src/stripeLightrailSplitTenderTransactions.test.ts
+++ b/src/stripeLightrailSplitTenderTransactions.test.ts
@@ -110,15 +110,6 @@ describe("stripeLightrailSplitTenderTransactions", () => {
                 const res = await lightrailSplitTender.createSplitTenderCharge(stripeOnlyParams, 0, stripe);
                 chai.assert.equal(res.stripeCharge.amount, stripeOnlyParams.amount);
             });
-
-            describe("error handling", () => {
-                it("re-throws a Stripe error (bad Stripe object)", async () => {
-                    const badStripe = require("stripe")("abc");
-                    splitTenderChargeParams.userSuppliedId = uuid();
-                    chai.assert.isRejected(lightrailSplitTender.createSplitTenderCharge(splitTenderChargeParams, 1, badStripe));
-                });
-            });
-
         });
 
         describe("using Stripe secret key", () => {
@@ -147,15 +138,35 @@ describe("stripeLightrailSplitTenderTransactions", () => {
                 chai.assert.equal(res.stripeCharge.amount, stripeOnlyParams.amount);
             });
 
-            describe("error handling", () => {
-                it("re-throws a Stripe error (bad Stripe API key)", async () => {
-                    const badStripeKey = "abc";
-                    splitTenderChargeParams.userSuppliedId = uuid();
-                    chai.assert.isRejected(lightrailSplitTender.createSplitTenderCharge(splitTenderChargeParams, 1, badStripeKey));
-                });
+        });
+
+        describe("error handling", () => {
+            it("re-throws a Stripe error (bad Stripe object)", async () => {
+                const badStripe = require("stripe")("abc");
+                splitTenderChargeParams.userSuppliedId = uuid();
+                chai.assert.isRejected(lightrailSplitTender.createSplitTenderCharge(splitTenderChargeParams, 1, badStripe));
             });
 
+            it("re-throws a Stripe error (bad Stripe API key)", async () => {
+                const badStripeKey = "abc";
+                splitTenderChargeParams.userSuppliedId = uuid();
+                chai.assert.isRejected(lightrailSplitTender.createSplitTenderCharge(splitTenderChargeParams, 1, badStripeKey));
+            });
+
+            it("re-throws a Lightrail error (pending phase)", async () => {
+                const badParams = {
+                    userSuppliedId: uuid(),
+                    currency: "USD",
+                    amount: 1000,
+                    shopperId: "bad-shopper",
+                    source: stripeTestToken
+                };
+                chai.assert.isRejected(lightrailSplitTender.createSplitTenderCharge(badParams, 1, stripe));
+            });
+
+            // it("re-throws a Lightrail error (capture phase)");         // requires stubbing a method: implement when tests are set up for this
         });
+
     });
 
     describe("simulateSplitTenderCharge()", () => {

--- a/src/stripeLightrailSplitTenderTransactions.ts
+++ b/src/stripeLightrailSplitTenderTransactions.ts
@@ -100,6 +100,7 @@ export async function createSplitTenderCharge(params: CreateSplitTenderChargePar
                         userSuppliedId: params.userSuppliedId + "-void",
                         metadata: appendSplitTenderMetadataForLightrail(params, splitTenderCharge.stripeCharge),
                     });
+                throw error;
             }
         }
     } else {


### PR DESCRIPTION
If the Stripe part of a split tender transaction throws an error, it should be surfaced. The previous flow swallowed it by catching the Stripe error, voiding the Lightrail transaction, and returning the 'split tender charge' object containing only a voided Lightrail transaction. New flow catches, voids, and then re-throws the Stripe error.

Also adds a test to cover the Lightrail-error scenario. Will need another when stubs/mocks are implemented in tests (until then, can only test for errors in the first 'pending' part of the Lightrail transaction; should also cover errors in the void/capture phase).